### PR TITLE
Make it easier to kill when running in Docker.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,9 @@ if (!module.parent) {
     });
 }
 
-
+// Make it easier to kill the process when being run through Docker
+process.on('SIGINT', function() {
+    process.exit();
+});
 
 module.exports = app;


### PR DESCRIPTION
When running in docker image, `ctrl-c` does not get passed through properly to Node.js, making it hard to kill the Docker container.  This piece of code makes it so `ctrl-c` kills the container / Node.js server.

Could you confirm that this has no effect when running through node natively (not Docker) @hershilpatel?