### PR TITLE
Add a process.exit on SIGTERM as well as SIGINT

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,5 +77,8 @@ if (!module.parent) {
 process.on('SIGINT', function() {
     process.exit();
 });
+process.on('SIGTERM', function() {
+    process.exit();
+});
 
 module.exports = app;


### PR DESCRIPTION
Docker sends a `SIGTERM` signal when you `docker stop` or `docker-compose stop` (or ctrl-c) a running container. Before, the bulk data server wouldn't stop on `SIGTERM`, and would have to wait for the timeout and resulting `SIGKILL` to stop running. This made stopping the inferno-site-overlay compose script much more annoying.